### PR TITLE
SPEC2006: Add MSan patch

### DIFF
--- a/infra/targets/spec2006/msan.patch
+++ b/infra/targets/spec2006/msan.patch
@@ -1,0 +1,72 @@
+--- spec2006-1.2/benchspec/CPU2006/403.gcc/src/sbitmap.c	2005-06-03 04:43:52.000000000 +0200
++++ spec2006-fixed/benchspec/CPU2006/403.gcc/src/sbitmap.c	2022-07-11 21:58:17.655489468 +0200
+@@ -69,20 +69,21 @@
+      one pointer).  Neither is a bad idea, but this is simpler for now.  */
+   {
+     /* Based on DEFAULT_ALIGNMENT computation in obstack.c.  */
+     struct { char x; SBITMAP_ELT_TYPE y; } align;
+     int alignment = (char *) & align.y - & align.x;
+     vector_bytes = (vector_bytes + alignment - 1) & ~ (alignment - 1);
+   }
+ 
+   amt = vector_bytes + (n_vecs * elm_bytes);
+   bitmap_vector = (sbitmap *) xmalloc (amt);
++  memset(bitmap_vector, 0, amt);
+ 
+   for (i = 0, offset = vector_bytes; i < n_vecs; i++, offset += elm_bytes)
+     {
+       sbitmap b = (sbitmap) ((char *) bitmap_vector + offset);
+ 
+       bitmap_vector[i] = b;
+       b->n_bits = n_elms;
+       b->size = size;
+       b->bytes = bytes;
+     }
+--- spec2006-1.2/benchspec/CPU2006/403.gcc/src/final.c	2005-06-03 04:43:52.000000000 +0200
++++ spec2006-fixed/benchspec/CPU2006/403.gcc/src/final.c	2022-07-11 22:07:24.645521334 +0200
+@@ -1013,20 +1013,21 @@
+ 		    max_skip = LABEL_ALIGN_AFTER_BARRIER_MAX_SKIP;
+ 		  }
+ 		break;
+ 	      }
+ 	}
+     }
+ #ifdef HAVE_ATTR_length
+ 
+   /* Allocate the rest of the arrays.  */
+   insn_lengths = (int *) xmalloc (max_uid * sizeof (*insn_lengths));
++  memset(insn_lengths, 0, max_uid * sizeof (*insn_lengths));
+   insn_lengths_max_uid = max_uid;
+   /* Syntax errors can lead to labels being outside of the main insn stream.
+      Initialize insn_addresses, so that we get reproducible results.  */
+   INSN_ADDRESSES_ALLOC (max_uid);
+ 
+   varying_length = (char *) xcalloc (max_uid, sizeof (char));
+ 
+   /* Initialize uid_align.  We scan instructions
+      from end to start, and keep in align_tab[n] the last seen insn
+      that does an alignment of at least n+1, i.e. the successor
+--- spec2006-1.2/benchspec/CPU2006/403.gcc/src/ggc-page.c	2005-06-03 04:43:52.000000000 +0200
++++ spec2006-fixed/benchspec/CPU2006/403.gcc/src/ggc-page.c	2022-07-11 22:39:17.994018831 +0200
+@@ -646,20 +646,21 @@
+ 
+       char *allocation, *a, *enda;
+       size_t alloc_size, head_slop, tail_slop;
+       int multiple_pages = (entry_size == G.pagesize);
+ 
+       if (multiple_pages)
+ 	alloc_size = GGC_QUIRE_SIZE * G.pagesize;
+       else
+ 	alloc_size = entry_size + G.pagesize - 1;
+       allocation = xmalloc (alloc_size);
++      memset(allocation, 0, alloc_size);
+ 
+       page = (char *) (((size_t) allocation + G.pagesize - 1) & -G.pagesize);
+       head_slop = page - allocation;
+       if (multiple_pages)
+ 	tail_slop = ((size_t) allocation + alloc_size) & (G.pagesize - 1);
+       else
+ 	tail_slop = alloc_size - entry_size - head_slop;
+       enda = allocation + alloc_size - tail_slop;
+ 
+       /* We allocated N pages, which are likely not aligned, leaving


### PR DESCRIPTION
This fixes the following three errors in the 403.gcc benchmark.

Just memsets the memory to zero. Doesn't influence the SPEC score
after some testing on O2.

```
==772298==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x274c2bf in sbitmap_a_and_b_or_c /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/sbitmap.c:350:11
    #1 0x201b9e7 in compute_earliest /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/lcm.c:221:8
    #2 0x2014438 in pre_edge_lcm /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/lcm.c:445:3
    #3 0x146a52a in compute_pre_data /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:4498:15
    #4 0x140826d in one_pre_gcse_pass /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:5099:7
    #5 0x1400f32 in gcse_main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:829:15
    #6 0x29ee4d8 in rest_of_compilation /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2837:13
    #7 0x529ee0 in c_expand_body /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #8 0x52871d in finish_function /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #9 0x3f284c in yyparse_1 /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #10 0x469c9f in yyparse /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #11 0x2a1070c in compile_file /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #12 0x29fb5ea in do_compile /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #13 0x29f78b1 in toplev_main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #14 0x6df0ba in main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #15 0x7f436ca2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #16 0x7f436ca29349 in __libc_start_main (/usr/lib/libc.so.6+0x29349) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #17 0x35f3b4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115

  Uninitialized value was created by a heap allocation
    #0 0x394b20 in malloc msan_interceptors.cpp:895:3
    #1 0x2d129b6 in xmalloc /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/xmalloc.c:141:12
    #2 0x27433e1 in sbitmap_vector_alloc /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/sbitmap.c:79:31
    #3 0x20141e8 in pre_edge_lcm /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/lcm.c:444:14
    #4 0x146a52a in compute_pre_data /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:4498:15
    #5 0x140826d in one_pre_gcse_pass /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:5099:7
    #6 0x1400f32 in gcse_main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/gcse.c:829:15
    #7 0x29ee4d8 in rest_of_compilation /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2837:13
    #8 0x529ee0 in c_expand_body /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #9 0x52871d in finish_function /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #10 0x3f284c in yyparse_1 /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #11 0x469c9f in yyparse /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #12 0x2a1070c in compile_file /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #13 0x29fb5ea in do_compile /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #14 0x29f78b1 in toplev_main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #15 0x6df0ba in main /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #16 0x7f436ca2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /spec/build/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/sbitmap.c:350:11 in sbitmap_a_and_b_or_c
Exiting
```

Next error:

```
==800520==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x15b0340 in get_attr_prefix_0f /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:20081:201
    #1 0x15a3194 in insn_default_length /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:390:38
    #2 0x11a19b9 in shorten_branches /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:1197:24
    #3 0x29f448b in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3473:3
    #4 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #5 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #6 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #7 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #8 0x2a1070c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #9 0x29fb5ea in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #10 0x29f78b1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #11 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #12 0x7f633bc2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #13 0x7f633bc29349 in __libc_start_main (/usr/lib/libc.so.6+0x29349) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #14 0x35f3b4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115

  Uninitialized value was stored to memory at
    #0 0x11960e3 in insn_current_reference_address /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:775:7
    #1 0x15b02e2 in get_attr_prefix_0f /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:20081:150
    #2 0x15a3194 in insn_default_length /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:390:38
    #3 0x11a19b9 in shorten_branches /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:1197:24
    #4 0x29f448b in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3473:3
    #5 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #6 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #7 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #8 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #9 0x2a1070c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #10 0x29fb5ea in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #11 0x29f78b1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #12 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #13 0x7f633bc2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

  Uninitialized value was stored to memory at
    #0 0x1197686 in align_fuzz /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:731:12
    #1 0x1196064 in insn_current_reference_address /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:776:10
    #2 0x15b02e2 in get_attr_prefix_0f /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:20081:150
    #3 0x15a3194 in insn_default_length /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:390:38
    #4 0x11a19b9 in shorten_branches /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:1197:24
    #5 0x29f448b in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3473:3
    #6 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #7 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #8 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #9 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #10 0x2a1070c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #11 0x29fb5ea in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #12 0x29f78b1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #13 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #14 0x7f633bc2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

  Uninitialized value was stored to memory at
    #0 0x1197012 in align_fuzz /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:724:18
    #1 0x1196064 in insn_current_reference_address /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:776:10
    #2 0x15b02e2 in get_attr_prefix_0f /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:20081:150
    #3 0x15a3194 in insn_default_length /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:390:38
    #4 0x11a19b9 in shorten_branches /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:1197:24
    #5 0x29f448b in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3473:3
    #6 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #7 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #8 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #9 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #10 0x2a1070c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #11 0x29fb5ea in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #12 0x29f78b1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #13 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #14 0x7f633bc2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

  Uninitialized value was created by a heap allocation
    #0 0x394b20 in malloc msan_interceptors.cpp:895:3
    #1 0x2d129b6 in xmalloc /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/xmalloc.c:141:12
    #2 0x119d1c2 in shorten_branches /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/final.c:1022:26
    #3 0x29f448b in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3473:3
    #4 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #5 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #6 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #7 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #8 0x2a1070c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #9 0x29fb5ea in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #10 0x29f78b1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #11 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #12 0x7f633bc2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-attrtab.c:20081:201 in get_attr_prefix_0f
Exiting
```

Next error:

```
==838500==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x29dd79b in exact_log2_wide /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:1616:7
    #1 0x1b3163e in peephole2_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-recog.c:56812:8
    #2 0x1b14671 in peephole2_insns /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-recog.c:58683:10
    #3 0x2337f5f in peephole2_optimize /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/recog.c:3098:14
    #4 0x29f36c5 in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3332:7
    #5 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #6 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #7 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #8 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #9 0x2a1071c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #10 0x29fb5fa in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #11 0x29f78c1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #12 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #13 0x7fd4a1a2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #14 0x7fd4a1a29349 in __libc_start_main (/usr/lib/libc.so.6+0x29349) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #15 0x35f3b4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115

  Uninitialized value was stored to memory at
    #0 0x29dd5a1 in exact_log2_wide /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:1613
    #1 0x1b3163e in peephole2_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-recog.c:56812:8
    #2 0x1b14671 in peephole2_insns /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/insn-recog.c:58683:10
    #3 0x2337f5f in peephole2_optimize /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/recog.c:3098:14
    #4 0x29f36c5 in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3332:7
    #5 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #6 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #7 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #8 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #9 0x2a1071c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #10 0x29fb5fa in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #11 0x29f78c1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #12 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10
    #13 0x7fd4a1a2928f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

  Uninitialized value was created by a heap allocation
    #0 0x394b20 in malloc msan_interceptors.cpp:895:3
    #1 0x2d129c6 in xmalloc /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/xmalloc.c:141:12
    #2 0x2bb3020 in alloc_page /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/ggc-page.c:655:20
    #3 0x2baf926 in ggc_alloc /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/ggc-page.c:881:19
    #4 0x149e1d6 in gen_rtx_fmt_i0 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/genrtl.c:634:8
    #5 0xeeab53 in gen_raw_REG /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/emit-rtl.c:325:11
    #6 0xeed05b in gen_rtx_REG /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/emit-rtl.c:430:10
    #7 0x11fc6fa in propagate_one_insn /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/flow.c:1724:29
    #8 0x11ef242 in propagate_block /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/flow.c:2026:14
    #9 0x11dc444 in update_life_info /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/flow.c:726:4
    #10 0x11ce2d9 in life_analysis /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/flow.c:477:3
    #11 0x29f0966 in rest_of_compilation /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:3034:3
    #12 0x529ee0 in c_expand_body /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:7119:3
    #13 0x52871d in finish_function /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-decl.c:6986:7
    #14 0x3f284c in yyparse_1 /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-parse.c:2186:5
    #15 0x469c9f in yyparse /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/c-lex.c:164:10
    #16 0x2a1071c in compile_file /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:2126:3
    #17 0x29fb5fa in do_compile /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5221:5
    #18 0x29f78c1 in toplev_main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:5255:5
    #19 0x6df0ba in main /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/main.c:35:10

SUMMARY: MemorySanitizer: use-of-uninitialized-value /specbuild/targets/spec2006/install/benchspec/CPU2006/403.gcc/build/build_base_infra-msan_tracking_O0.0000/toplev.c:1616:7 in exact_log2_wide
Exiting

```