### PR TITLE
Run randomized builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *~
 *.swp
+.idea

--- a/infra/commands/__init__.py
+++ b/infra/commands/__init__.py
@@ -4,3 +4,4 @@ from .config import ConfigCommand, PkgConfigCommand
 from .exec_hook import ExecHookCommand
 from .report import ReportCommand
 from .run import RunCommand
+from .run_random import RunRandomCommand

--- a/infra/commands/report.py
+++ b/infra/commands/report.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import re
 import csv
@@ -144,6 +145,11 @@ class ReportCommand(Command):
                 choices=self.instances,
                 help="report each field as overhead relative to this baseline",
             )
+            tparser.add_argument(
+                "--show-baseline",
+                action="store_true",
+                help="if reporting overheads, also report the raw baseline values",
+            )
 
             tparser.add_argument(
                 "--groupby",
@@ -286,10 +292,12 @@ class ReportCommand(Command):
                     if f in result:
                         grouped.setdefault((key, f), []).append(result[f])
 
+        show_baseline = getattr(ctx.args, "show_baseline", False)
+
         header = [ctx.args.groupby]
         human_header = ["\n\n" + ctx.args.groupby]
         for instance in instances:
-            if instance == baseline_instance:
+            if not show_baseline and instance == baseline_instance:
                 continue
 
             for i, (f, aggr) in enumerate(fields):
@@ -299,22 +307,27 @@ class ReportCommand(Command):
                     human_header.append(prefix + ag)
                     prefix = "\n\n"
 
+        output_mode = getattr(ctx.args, "output_mode", "table")
+
         data: list[list[ResultVal | None]] = []
+        per_instance: dict[str, dict[str, dict[str, ResultVal | None]]] = {}
         for groupby_value in groupby_values:
-            baseline_results = {}
+            baseline_results: dict[tuple[str, str, str], ResultVal] = {}
             if baseline_instance:
                 key = groupby_value, baseline_instance
                 for f, aggr in fields:
                     for ag in aggr:
                         series = grouped.get((key, f), [-1])
                         value = _aggregate_fns[ag](series)
-                        baseline_results[(groupby_value, f)] = value
+                        baseline_results[(groupby_value, f, ag)] = value
 
             row: list[ResultVal | None] = [groupby_value]
             for instance in instances:
-                if instance == baseline_instance:
+                if not show_baseline and instance == baseline_instance:
                     continue
 
+                if output_mode == "json":
+                    per_instance.setdefault(instance, {})
                 key = groupby_value, instance
                 for f, aggr in fields:
                     for ag in aggr:
@@ -323,9 +336,22 @@ class ReportCommand(Command):
                         else:
                             series = grouped[(key, f)]
                             value = _aggregate_fns[ag](series)
-                            if baseline_results and isinstance(value, (int, float)):
-                                value /= baseline_results[(groupby_value, f)]
+                            if (
+                                instance != baseline_instance
+                                and baseline_results
+                                and isinstance(value, (int, float))
+                            ):
+                                value /= baseline_results[
+                                    (groupby_value, f, ag)
+                                ]
                         row.append(value)
+                        if output_mode == "json":
+                            per_instance[instance].setdefault(
+                                str(groupby_value), {}
+                            )
+                            per_instance[instance][str(groupby_value)][
+                                f"{f}:{ag}"
+                            ] = value
             data.append(row)
 
         if baseline_instance:
@@ -349,7 +375,10 @@ class ReportCommand(Command):
             data.append(aggregate_row)
             table_options["inner_footing_row_border"] = True
 
-        report_table(ctx, header, human_header, data, title, **table_options)
+        if output_mode == "json":
+            _report_json(per_instance)
+        else:
+            report_table(ctx, header, human_header, data, title, **table_options)
 
     def _parse_fields(self, ctx: Context, target: Target) -> FieldAggregators:
         for arg in chain.from_iterable(ctx.args.field):
@@ -408,6 +437,13 @@ def add_table_report_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
+        "--output-mode",
+        choices=("table", "json"),
+        default="table",
+        help="output format: table (default) or machine-readable JSON",
+    )
+
+    parser.add_argument(
         "--precision",
         type=int,
         default=3,
@@ -423,6 +459,27 @@ def add_table_report_args(parser: argparse.ArgumentParser) -> None:
             dest="table",
             help="short for --table=" + mode,
         )
+
+
+def _report_json(
+    per_instance: dict[str, dict[str, dict[str, Any]]],
+) -> None:
+    """Print aggregated results as machine-readable JSON.
+
+    The output structure is::
+
+        {
+            "<instance>": {
+                "<groupby_value>": {
+                    "<field>:<aggregator>": <value>,
+                    ...
+                },
+                ...
+            },
+            ...
+        }
+    """
+    print(json.dumps(per_instance, indent=2))
 
 
 def report_table(

--- a/infra/commands/run_random.py
+++ b/infra/commands/run_random.py
@@ -1,0 +1,152 @@
+import copy
+import datetime
+import os
+import random
+import argparse
+
+from ..command import Command, load_deps
+from ..context import Context
+from ..util import FatalError
+from .build import BuildCommand
+
+
+class RunRandomCommand(Command):
+    """Build and run a target multiple times, each with a fresh random seed.
+
+    Each iteration generates a unique 24-bit random seed, sets it on
+    ``ctx.rngseed`` and ``ctx.uniqueid``, performs a full rebuild, and then
+    runs the target.  This is designed for use with :class:`RandomizingClang`
+    which substitutes the ``RNGSEED`` placeholder in compiler flags.
+    """
+
+    @property
+    def name(self) -> str:
+        return "run-random"
+
+    @property
+    def description(self) -> str:
+        return "run a single target program multiple times with fresh builds in between"
+
+    def add_args(self, parser: argparse.ArgumentParser) -> None:
+        target_parsers = parser.add_subparsers(
+            title="target",
+            metavar="TARGET",
+            dest="target",
+            help=" | ".join([target.name for target in self.targets.all()]),
+        )
+        target_parsers.required = True
+
+        for name, target in self.targets.items():
+            tparser = target_parsers.add_parser(
+                name=name,
+                help=f"run-random configuration options for {target.name}",
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            )
+
+            tparser.add_argument(
+                "instances",
+                nargs="+",
+                metavar="INSTANCE",
+                choices=[instance.name for instance in self.instances.all()],
+                help=" | ".join(
+                    [instance.name for instance in self.instances.all()]
+                ),
+            )
+            tparser.add_argument(
+                "--force-rebuild-deps",
+                action="store_true",
+                help="force rebuilding of dependencies (implies --build)",
+            )
+            tparser.add_argument(
+                "-i",
+                "--iterations",
+                metavar="ITERATIONS",
+                type=int,
+                default=1,
+                help="number of runs per benchmark",
+            )
+
+            self.add_pool_args(tparser)
+            target.add_run_args(tparser)
+
+            for instance in self.instances.values():
+                instance.add_build_args(tparser)
+                instance.add_run_args(tparser)
+
+    def run(self, ctx: Context) -> None:
+        target = self.targets[ctx.args.target]
+        instances = self.instances.select(ctx.args.instances)
+        pool = self.make_pool(ctx)
+        if pool is None:
+            raise FatalError("run-random requires --parallel (e.g. --parallel proc)")
+        self.enable_run_log(ctx)
+
+        iterations = ctx.args.iterations
+        orig_cwd = os.getcwd()
+
+        for instance in instances:
+            ctx.log.info(f"building and running instance {instance.name}")
+
+            for iteration in range(iterations):
+                seed = str(random.randint(0, 0xFFFFFF))
+                ctx.log.info(
+                    f"starting iteration {iteration + 1} with seed {seed}"
+                )
+
+                # Build phase: use a dedicated context copy so that
+                # BuildCommand's internal configure() call does not
+                # pollute the run-phase context.
+                build_ctx = ctx.copy()
+                build_ctx.args = copy.deepcopy(ctx.args)
+                build_ctx.rngseed = seed
+                build_ctx.uniqueid = seed
+                build_ctx.args.dry_run = False
+                build_ctx.args.targets = [build_ctx.args.target]
+                build_ctx.args.packages = []
+                build_ctx.args.deps_only = False
+                build_ctx.args.clean = False
+                build_ctx.args.relink = False
+                build_ctx.args.iterations = 1
+                build_ctx.args.instances = [instance.name]
+
+                build_command = BuildCommand()
+                build_command.instances = self.instances
+                build_command.targets = self.targets
+                build_command.packages = self.packages
+                build_command.run(build_ctx)
+
+                # Run phase: start from a fresh copy of the original
+                # context so flags are not duplicated by a second
+                # configure() call.
+                run_ctx = ctx.copy()
+                run_ctx.args = copy.deepcopy(ctx.args)
+                run_ctx.rngseed = seed
+                run_ctx.uniqueid = seed
+                run_ctx.args.iterations = 1
+                # Give each iteration a unique starttime so that
+                # outfile_path() places results into separate run
+                # directories instead of overwriting the previous
+                # iteration's logs.
+                run_ctx.starttime = datetime.datetime.now()
+
+                load_deps(run_ctx, target)
+                load_deps(run_ctx, instance)
+                instance.configure(run_ctx)
+                instance.prepare_run(run_ctx)
+
+                ctx.log.info(f"running {target.name}-{instance.name}")
+                target.goto_rootdir(run_ctx)
+                target.run_hooks_pre_run(run_ctx, instance)
+                target.run(run_ctx, instance, pool)
+                target.run_hooks_post_run(run_ctx, instance)
+                os.chdir(orig_cwd)
+
+                instance.process_run(run_ctx)
+                os.chdir(orig_cwd)
+
+                # Wait for all pool jobs to finish before the next
+                # iteration, otherwise the next build would overwrite
+                # binaries still in use by the current run.
+                pool.wait_all()
+
+        pool.wait_all()

--- a/infra/context.py
+++ b/infra/context.py
@@ -182,6 +182,12 @@ class Context:
     #: In practice it is either empty or ``['-flto']`` when compiling with LLVM.
     lib_ldflags: list[str] = field(default_factory=list)
 
+    #: Random seed for randomized builds (set by ``run-random`` command).
+    rngseed: str = ""
+
+    #: Unique identifier per build iteration (set by ``run-random`` command).
+    uniqueid: str = ""
+
     def add_flags(
         self,
         flags: Iterable[str] | str,

--- a/infra/instances/clang.py
+++ b/infra/instances/clang.py
@@ -4,6 +4,7 @@ from ..context import Context
 from ..instance import Instance
 from ..package import Package
 from ..packages import LLVM, Gperftools
+from ..util import FatalError
 
 
 class Clang(Instance):
@@ -55,7 +56,6 @@ class Clang(Instance):
             yield self.gperftools
 
     def configure(self, ctx: Context) -> None:
-        self.llvm.configure(ctx)
 
         if self.alloc == "tcmalloc":
             self.gperftools.configure(ctx)
@@ -70,3 +70,98 @@ class Clang(Instance):
             ctx.cxxflags += ["-flto"]
             ctx.ldflags += ["-flto"]
             ctx.lib_ldflags += ["-flto"]
+
+
+class ParameterizedClang(Clang):
+    """
+    Extends :class:`Clang` with custom naming and extra compile/link flags.
+
+    Extra flags are appended after :class:`Clang`'s own flags during
+    :func:`configure`.
+
+    :param llvm: an LLVM package containing the relevant clang version
+    :param instance_name: custom name for this instance
+    :param extra_cflags: additional C compiler flags
+    :param extra_cxxflags: additional C++ compiler flags
+    :param extra_ldflags: additional linker flags
+    :param extra_lib_ldflags: additional library linker flags
+    :param optlevel: optimization level for ``-O`` (default: 2)
+    :param lto: whether to apply link-time optimizations
+    :param alloc: which allocator to use (default: system)
+    """
+
+    def __init__(
+        self,
+        llvm: LLVM,
+        instance_name: str,
+        extra_cflags: list[str] | None = None,
+        extra_cxxflags: list[str] | None = None,
+        extra_ldflags: list[str] | None = None,
+        extra_lib_ldflags: list[str] | None = None,
+        *,
+        optlevel: int | str = 2,
+        lto: bool = False,
+        alloc: str = "system",
+    ) -> None:
+        super().__init__(llvm, optlevel=optlevel, lto=lto, alloc=alloc)
+        self.instance_name = instance_name
+        self.extra_cflags = extra_cflags or []
+        self.extra_cxxflags = extra_cxxflags or []
+        self.extra_ldflags = extra_ldflags or []
+        self.extra_lib_ldflags = extra_lib_ldflags or []
+
+    @property
+    def name(self) -> str:
+        return self.instance_name
+
+    def add_all_flags(self, flags: list[str]) -> None:
+        """Append ``flags`` to all flag lists (cflags, cxxflags, ldflags, lib_ldflags)."""
+        self.extra_cflags.extend(flags)
+        self.extra_cxxflags.extend(flags)
+        self.extra_ldflags.extend(flags)
+        self.extra_lib_ldflags.extend(flags)
+
+    def add_linker_flags(self, flags: list[str]) -> None:
+        """Append ``flags`` to the extra linker flags."""
+        self.extra_ldflags.extend(flags)
+
+    def add_lib_linker_flags(self, flags: list[str]) -> None:
+        """Append ``flags`` to the extra library linker flags."""
+        self.extra_lib_ldflags.extend(flags)
+
+    def configure(self, ctx: Context) -> None:
+        super().configure(ctx)
+        ctx.cflags += self.extra_cflags
+        ctx.cxxflags += self.extra_cxxflags
+        ctx.ldflags += self.extra_ldflags
+        ctx.lib_ldflags += self.extra_lib_ldflags
+
+
+class RandomizingClang(ParameterizedClang):
+    """
+    Extends :class:`ParameterizedClang` to substitute the ``RNGSEED``
+    placeholder in all compiler flags with the actual random seed from
+    ``ctx.rngseed``.
+
+    This is intended to be used with the ``run-random`` command, which
+    sets ``ctx.rngseed`` to a fresh value for each iteration.
+
+    Raises :class:`FatalError` if ``ctx.rngseed`` is empty when
+    :func:`configure` is called.
+    """
+
+    def configure(self, ctx: Context) -> None:
+        super().configure(ctx)
+        if not ctx.rngseed:
+            raise FatalError(
+                f"Instance '{self.name}' requires an RNG seed. "
+                "Currently only the run-random command creates such a seed."
+            )
+
+        def replace_placeholder(flag: str) -> str:
+            return flag.replace("RNGSEED", ctx.rngseed)
+
+        ctx.cflags = list(map(replace_placeholder, ctx.cflags))
+        ctx.cxxflags = list(map(replace_placeholder, ctx.cxxflags))
+        ctx.ldflags = list(map(replace_placeholder, ctx.ldflags))
+        ctx.lib_ldflags = list(map(replace_placeholder, ctx.lib_ldflags))

--- a/infra/parallel.py
+++ b/infra/parallel.py
@@ -58,7 +58,7 @@ class Job:
 
     @property
     def stderr_io(self) -> IO | None:
-        return self.proc.stdout_io
+        return self.proc.stderr_io
 
     def poll(self) -> int | None:
         return self.proc.poll()
@@ -71,6 +71,7 @@ class Job:
 class ProcessJob(Job):
     stdout_handle: IO | None = None
     stderr_handle: IO | None = None
+    outfiles: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -336,6 +337,7 @@ class ProcessPool(Pool):
                     errs="",
                     stdout_handle=open(f"{outfile}.stdout.log", mode="w") if proc.stdout_io is not None else None,
                     stderr_handle=open(f"{outfile}.stderr.log", mode="w") if proc.stderr_io is not None else None,
+                    outfiles=outfiles,
                 )
             else:
                 RuntimeError(f"Failed to create process {jobid} for command: {cmd}")

--- a/infra/setup.py
+++ b/infra/setup.py
@@ -247,6 +247,7 @@ class Setup:
         self.add_command(commands.ConfigCommand())
         self.add_command(commands.PkgConfigCommand())
         self.add_command(commands.ExecHookCommand())
+        self.add_command(commands.RunRandomCommand())
 
         self._parse_argv()
         self._create_dirs()

--- a/infra/targets/spec2017/__init__.py
+++ b/infra/targets/spec2017/__init__.py
@@ -415,6 +415,8 @@ class SPEC2017(Target):
 
                 def onsuccess_parse_log(job: Job) -> None:
                     for job_outfile in job.outfiles:
+                        if job_outfile.endswith(".stderr.log"):
+                            continue
                         process_log(ctx, job_outfile, self, write_cache=True)
 
                 self._run_bash(

--- a/infra/util.py
+++ b/infra/util.py
@@ -419,8 +419,11 @@ class Process:
         if self.proc is None:
             raise ProcessLookupError("Invalid (None) process has no stdout!")
 
-        if isinstance(self.proc.stdout, IO):
+        if isinstance(self.proc.stdout, (io.IOBase, io.TextIOWrapper)):
             return self.proc.stdout
+
+        if self.proc.stdout is None:
+            return None
 
         raise ValueError(f"Cannot get stdout IO stream; stdout is {type(self.proc.stdout)}")
 
@@ -437,8 +440,11 @@ class Process:
         if self.proc is None:
             raise ProcessLookupError("Invalid (None) process has no stderr!")
 
-        if isinstance(self.proc.stderr, IO):
+        if isinstance(self.proc.stderr, (io.IOBase, io.TextIOWrapper)):
             return self.proc.stderr
+
+        if self.proc.stderr is None:
+            return None
 
         raise ValueError(f"Cannot get stderr IO stream; stderr is {type(self.proc.stderr)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+import logging
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from infra.context import Context, ContextPaths
+
+
+@pytest.fixture
+def tmp_paths(tmp_path: str) -> ContextPaths:
+    """Create a ContextPaths pointing at temporary directories."""
+    setup_path = os.path.join(str(tmp_path), "setup.py")
+    # Create the setup.py file so root is tmp_path
+    with open(setup_path, "w") as f:
+        f.write("")
+
+    paths = ContextPaths(
+        infra=os.path.join(str(tmp_path), "infra"),
+        setup=setup_path,
+        workdir=str(tmp_path),
+    )
+
+    # Create directories that the infra expects to exist
+    os.makedirs(paths.log, exist_ok=True)
+    os.makedirs(paths.packages, exist_ok=True)
+    os.makedirs(paths.targets, exist_ok=True)
+    os.makedirs(paths.pool_results, exist_ok=True)
+
+    return paths
+
+
+@pytest.fixture
+def ctx(tmp_paths: ContextPaths) -> Context:
+    """Create a minimal Context for testing."""
+    logger = logging.getLogger("test")
+    logger.addHandler(logging.NullHandler())
+    return Context(paths=tmp_paths, log=logger)
+
+
+@pytest.fixture
+def mock_llvm() -> MagicMock:
+    llvm = MagicMock()
+    llvm.configure = MagicMock()
+    return llvm
+
+
+@pytest.fixture
+def mock_target() -> MagicMock:
+    target = MagicMock()
+    target.name = "test-target"
+    target.add_run_args = MagicMock()
+    target.add_build_args = MagicMock()
+    target.goto_rootdir = MagicMock()
+    target.run_hooks_pre_run = MagicMock()
+    target.run = MagicMock()
+    target.run_hooks_post_run = MagicMock()
+    return target
+
+
+@pytest.fixture
+def mock_instance() -> MagicMock:
+    instance = MagicMock()
+    instance.name = "test-instance"
+    instance.add_build_args = MagicMock()
+    instance.add_run_args = MagicMock()
+    instance.configure = MagicMock()
+    instance.prepare_run = MagicMock()
+    instance.process_run = MagicMock()
+    return instance

--- a/tests/test_randomizing_clang.py
+++ b/tests/test_randomizing_clang.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import MagicMock
+
+from infra.context import Context
+from infra.instances.clang import ParameterizedClang, RandomizingClang
+from infra.util import FatalError
+
+
+class TestParameterizedClang:
+    def test_extra_flags_applied(self, ctx: Context, mock_llvm: MagicMock) -> None:
+        inst = ParameterizedClang(
+            mock_llvm,
+            "test",
+            extra_cflags=["-Dfoo"],
+            extra_cxxflags=["-Dbar"],
+            extra_ldflags=["-lbaz"],
+            extra_lib_ldflags=["-lqux"],
+        )
+        inst.configure(ctx)
+        assert "-Dfoo" in ctx.cflags
+        assert "-Dbar" in ctx.cxxflags
+        assert "-lbaz" in ctx.ldflags
+        assert "-lqux" in ctx.lib_ldflags
+
+class TestRandomizingClang:
+    def test_seed_substitution_in_flags(
+        self, ctx: Context, mock_llvm: MagicMock
+    ) -> None:
+        inst = RandomizingClang(
+            mock_llvm,
+            "rando",
+            extra_cflags=["-seed=RNGSEED"],
+            extra_ldflags=["-Wl,--rng=RNGSEED"],
+        )
+        ctx.rngseed = "12345"
+        inst.configure(ctx)
+        assert "-seed=12345" in ctx.cflags
+        assert "-Wl,--rng=12345" in ctx.ldflags
+
+    def test_missing_seed_raises_error(
+        self, ctx: Context, mock_llvm: MagicMock
+    ) -> None:
+        inst = RandomizingClang(mock_llvm, "rando")
+        assert ctx.rngseed == ""
+        with pytest.raises(FatalError, match="requires an RNG seed"):
+            inst.configure(ctx)
+
+    def test_multiple_placeholders_in_same_flag(
+        self, ctx: Context, mock_llvm: MagicMock
+    ) -> None:
+        inst = RandomizingClang(
+            mock_llvm,
+            "rando",
+            extra_cflags=["-a=RNGSEED -b=RNGSEED"],
+        )
+        ctx.rngseed = "99"
+        inst.configure(ctx)
+        assert "-a=99 -b=99" in ctx.cflags

--- a/tests/test_run_random.py
+++ b/tests/test_run_random.py
@@ -1,0 +1,106 @@
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infra.commands.run_random import RunRandomCommand
+from infra.context import Context
+from infra.util import Index
+
+
+@pytest.fixture
+def targets_index(mock_target: MagicMock) -> Index:
+    idx: Index = Index("target")
+    idx[mock_target.name] = mock_target
+    return idx
+
+
+@pytest.fixture
+def instances_index(mock_instance: MagicMock) -> Index:
+    idx: Index = Index("instance")
+    idx[mock_instance.name] = mock_instance
+    return idx
+
+
+class TestRunRandomCommand:
+    @patch("infra.commands.run_random.BuildCommand")
+    def test_each_iteration_gets_unique_seed_and_original_ctx_is_untouched(
+        self,
+        MockBuildCommand: MagicMock,
+        ctx: Context,
+        mock_target: MagicMock,
+        mock_instance: MagicMock,
+        targets_index: Index,
+        instances_index: Index,
+    ) -> None:
+        cmd = RunRandomCommand()
+        cmd.instances = instances_index
+        cmd.targets = targets_index
+        cmd.packages = Index("package")
+        cmd.make_pool = MagicMock(return_value=MagicMock())
+
+        ctx.args = argparse.Namespace(
+            target="test-target",
+            instances=["test-instance"],
+            iterations=3,
+        )
+
+        MockBuildCommand.return_value = MagicMock()
+
+        # Snapshot original state
+        original_rngseed = ctx.rngseed
+        original_uniqueid = ctx.uniqueid
+        original_cflags = list(ctx.cflags)
+
+        cmd.run(ctx)
+
+        # Each iteration should have produced a run with a distinct seed
+        run_seeds = [
+            c[0][0].rngseed for c in mock_target.run.call_args_list
+        ]
+        assert len(run_seeds) == 3
+        assert len(set(run_seeds)) == 3, f"expected 3 unique seeds, got {run_seeds}"
+
+        # The caller's context must be untouched
+        assert ctx.rngseed == original_rngseed
+        assert ctx.uniqueid == original_uniqueid
+        assert ctx.cflags == original_cflags
+
+    @patch("infra.commands.run_random.BuildCommand")
+    def test_flags_do_not_accumulate_across_iterations(
+        self,
+        MockBuildCommand: MagicMock,
+        ctx: Context,
+        mock_target: MagicMock,
+        mock_instance: MagicMock,
+        targets_index: Index,
+        instances_index: Index,
+    ) -> None:
+        """Verify that configure() starts from a clean slate each iteration."""
+        cmd = RunRandomCommand()
+        cmd.instances = instances_index
+        cmd.targets = targets_index
+        cmd.packages = Index("package")
+        cmd.make_pool = MagicMock(return_value=MagicMock())
+
+        ctx.args = argparse.Namespace(
+            target="test-target",
+            instances=["test-instance"],
+            iterations=3,
+        )
+
+        MockBuildCommand.return_value = MagicMock()
+
+        # Make configure add a flag so we can detect accumulation
+        def add_flag(c: Context) -> None:
+            c.cflags.append("-Xtest")
+
+        mock_instance.configure = MagicMock(side_effect=add_flag)
+
+        cmd.run(ctx)
+
+        # Each run context should have exactly 1 -Xtest; if flags
+        # accumulated the later iterations would have 2 or 3.
+        for c in mock_target.run.call_args_list:
+            run_ctx = c[0][0]
+            assert run_ctx.cflags.count("-Xtest") == 1


### PR DESCRIPTION
- Add a json export to report that generates a file that is machine-parsable, e.g. for plot generation
- Add a command that rebuilds on every run and replaces a placeholder with a random seed. This is useful for randomized tests, e.g. when benchmarking randomizing compilers.

Disclaimer: the changes were originally written by me (see https://github.com/ucsrl/r2c-benchmarking), but now cleaned up and polished for the PR by Claude Code (under supervision). 